### PR TITLE
Cleanup output and scripting

### DIFF
--- a/etc/portage/postsync.d/sync_cache
+++ b/etc/portage/postsync.d/sync_cache
@@ -4,6 +4,6 @@ source /etc/portage/check-portdir.sh
 source /etc/init.d/functions.sh
 source /etc/portage/util-functions.sh
 
-einfo "syncing metadata cache"
-egencache --jobs=8 --repo=gentoo --update --update-use-local-desc || die "egencache failed!"
-einfo "done syncing metadata cache"
+ebegin "Syncing metadata cache"
+egencache --jobs=8 --repo=gentoo --update --update-use-local-desc
+eend $?

--- a/etc/portage/postsync.d/sync_dtd
+++ b/etc/portage/postsync.d/sync_dtd
@@ -4,16 +4,11 @@ source /etc/portage/check-portdir.sh
 source /etc/init.d/functions.sh
 source /etc/portage/util-functions.sh
 
-einfo "updating dtd directory"
-
-cd "${PORTDIR}"/metadata || die "could not cd into '${PORTDIR}/metadata'!"
-if [[ -e dtd ]] ; then
-	einfo "dtd dir already exists, updating..."
-	cd dtd || die "could not cd into 'dtd'!"
-	git pull --ff || die "could not pull updates!"
+DTDDIR="${PORTDIR}"/metadata/dtd
+ebegin "Updating DTDs"
+if [[ -e $DTDDIR ]]; then
+	git -C "$DTDDIR" pull --ff
 else
-	einfo "dtd directory does not exist, cloning..."
-	git clone https://anongit.gentoo.org/git/data/dtd.git || die "could not clone repository!"
+	git clone https://anongit.gentoo.org/git/data/dtd.git "$DTDDIR"
 fi
-
-einfo "done updating dtd directory"
+eend "$?"

--- a/etc/portage/postsync.d/sync_glsa
+++ b/etc/portage/postsync.d/sync_glsa
@@ -4,16 +4,11 @@ source /etc/portage/check-portdir.sh
 source /etc/init.d/functions.sh
 source /etc/portage/util-functions.sh
 
-einfo "updating glsa directory"
-
-cd "${PORTDIR}"/metadata || die "could not cd into '${PORTDIR}/metadata'!"
-if [[ -e glsa ]] ; then
-	einfo "glsa dir already exists, updating..."
-	cd glsa || die "could not cd into 'glsa'!"
-	git pull --ff || die "could not pull updates!"
+GLSADIR="${PORTDIR}"/metadata/glsa
+ebegin "Updating GLSAs"
+if [[ -e $GLSADIR ]]; then
+	git -C "$GLSADIR" pull --ff
 else
-	einfo "glsa directory does not exist, cloning..."
-	git clone https://anongit.gentoo.org/git/data/glsa.git || die "could not clone repository!"
+	git clone https://anongit.gentoo.org/git/data/glsa.git "$GLSADIR"
 fi
-
-einfo "done updating glsa directory"
+eend "$?"

--- a/etc/portage/postsync.d/sync_herds_xml
+++ b/etc/portage/postsync.d/sync_herds_xml
@@ -4,10 +4,6 @@ source /etc/portage/check-portdir.sh
 source /etc/init.d/functions.sh
 source /etc/portage/util-functions.sh
 
-einfo "updating herds.xml"
-
-cd "${PORTDIR}"/metadata || die "could not cd into '${PORTDIR}/metadata'!"
-[[ -e "${PORTDIR}"/metadata/herds.xml ]] && { rm "${PORTDIR}"/metadata/herds.xml || die "failed to rm herds.xml!" ;}
-wget https://gitweb.gentoo.org/data/api.git/plain/files/packages/herds.xml || die "failed to wget herds.xml"
-
-einfo "done updating herds.xml"
+ebegin "Updating herds.xml"
+wget -O "${PORTDIR}"/metadata/herds.xml https://gitweb.gentoo.org/data/api.git/plain/files/packages/herds.xml
+eend $?

--- a/etc/portage/postsync.d/sync_news
+++ b/etc/portage/postsync.d/sync_news
@@ -4,25 +4,22 @@ source /etc/portage/check-portdir.sh
 source /etc/init.d/functions.sh
 source /etc/portage/util-functions.sh
 
-einfo "updating news items"
-
-cd "${PORTDIR}"/metadata || die "could not cd into '${PORTDIR}/metadata'!"
-if [[ -e news ]] ; then
-	einfo "news dir already exists, updating..."
-	cd news || die "could not cd into 'news'!"
-	git pull --ff || die "could not pull updates!"
+NEWSDIR="${PORTDIR}"/metadata/news
+ebegin "Updating news items"
+if [[ -e $NEWSDIR ]]; then
+	git -C "$NEWSDIR" pull --ff
 else
-	einfo "glsa directory does not exist, cloning..."
-	git clone https://anongit.gentoo.org/git/proj/gentoo-news.git news || die "could not clone repository!"
+	git clone https://anongit.gentoo.org/git/proj/gentoo-news.git "$NEWSDIR"
 fi
+eend_die $?
 
-cd "${PORTDIR}"/metadata/news || die "failed to cd into ${PORTDIR}/metadata/news"
-git clean -fdxq || die "failed to clean git repo!"
+ebegin "Cleaning news git repo"
+git -C "$NEWSDIR" clean -fdxq
+eend_die $?
 
-if [[ -n "$(find . -mindepth 1 -maxdepth 1 -type d -name "*-*-*")" ]] ; then
-	die "it seems the repository format of proj/gentoo-news has changed! Update your script!"
-else
-	cp -a */* . || die "could not copy news dirs to base news dir!"
-fi
+[[ -n "$(find "$NEWSDIR" -mindepth 1 -maxdepth 1 -type d -name "*-*-*")" ]] && \
+	die "It seems the repository format of proj/gentoo-news has changed! Update your script!"
 
-einfo "done updating news items"
+ebegin "Copying news to base directory"
+cp -a "$NEWSDIR"/*/* "$NEWSDIR"
+eend $?

--- a/etc/portage/util-functions.sh
+++ b/etc/portage/util-functions.sh
@@ -2,6 +2,11 @@
 
 source /etc/init.d/functions.sh
 
+eend_die() {
+	eend "$@"
+	[[ $1 -ne 0 ]] && exit $1
+}
+
 die() {
 	eerror "$*"
 	exit 1


### PR DESCRIPTION
Using ebegin/eend makes things a bit cleaner and Gentoo-ish, and we can also clean up the scripts in general by using git's -C option.
