### PR TITLE
run emerge --check-news after syncing news to display the new news count

### DIFF
--- a/etc/portage/postsync.d/sync_news
+++ b/etc/portage/postsync.d/sync_news
@@ -20,3 +20,5 @@ eend_die $?
 ebegin "Copying news to base directory"
 cp -a "${NEWSDIR}"/*/* "${NEWSDIR}"
 eend $?
+
+emerge --check-news


### PR DESCRIPTION
Currently, when running `emerge --sync` while using this config, `emerge` will not display the unread news items count as it would otherwise do. This is because `emerge` checks for unread news before it runs the scripts in `/etc/portage/postsync.d`. If you run `emerge` again, then the news count will be displayed. One solution is to update the config to do that for us (i.e. rerun `emerge` for us).

The are two small downsides to this approach: The message will be display twice when there were unread news items before the invocation of `emerge --sync`, eg:

```
>>> Syncing repository 'gentoo' into '/usr/portage'...
/usr/bin/git pull
Already up-to-date.
=== Sync completed for gentoo

 * IMPORTANT: 1 news items need reading for repository 'gentoo'.
 * Use eselect news read to view new items.

 * Fetching pre-generated metadata cache for gentoo repository ...        [ ok ]
 * Updating metadata cache for repositories:
 *   local ...                                                            [ ok ]
 *   gentoo ...                                                           [ ok ]
 * Updating DTDs ...                                                      [ ok ]
 * Updating GLSAs ...                                                     [ ok ]
 * Updating herds.xml ...                                                 [ ok ]
 * Updating news items ...                                                [ ok ]
 * Cleaning news git repo ...                                             [ ok ]
 * Copying news to base directory ...                                     [ ok ]

 * IMPORTANT: 2 news items need reading for repository 'gentoo'.
 * Use eselect news read to view new items.
```

Secondly, if there are no new news items, a message will still be displayed:

```
>>> Syncing repository 'gentoo' into '/usr/portage'...
/usr/bin/git pull
Already up-to-date.
=== Sync completed for gentoo
 * Fetching pre-generated metadata cache for gentoo repository ...        [ ok ]
 * Updating metadata cache for repositories:
 *   local ...                                                            [ ok ]
 *   gentoo ...                                                           [ ok ]
 * Updating DTDs ...                                                      [ ok ]
 * Updating GLSAs ...                                                     [ ok ]
 * Updating herds.xml ...                                                 [ ok ]
 * Updating news items ...                                                [ ok ]
 * Cleaning news git repo ...                                             [ ok ]
 * Copying news to base directory ...                                     [ ok ]
 * No news items were found.
```

Overall, I think these issues are minor and the trade-off is acceptable.
