### PR TITLE
Use functions.sh from gentoo-functions instead of the one from openrc

### DIFF
--- a/etc/portage/repo.postsync.d/sync_gentoo_cache
+++ b/etc/portage/repo.postsync.d/sync_gentoo_cache
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-source /etc/init.d/functions.sh
+source /lib/gentoo/functions.sh
 
 repository_name="${1}"
 repository_path="${3}"

--- a/etc/portage/repo.postsync.d/sync_gentoo_dtd
+++ b/etc/portage/repo.postsync.d/sync_gentoo_dtd
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-source /etc/init.d/functions.sh
+source /lib/gentoo/functions.sh
 
 repository_name="${1}"
 repository_path="${3}"

--- a/etc/portage/repo.postsync.d/sync_gentoo_glsa
+++ b/etc/portage/repo.postsync.d/sync_gentoo_glsa
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-source /etc/init.d/functions.sh
+source /lib/gentoo/functions.sh
 
 repository_name="${1}"
 repository_path="${3}"

--- a/etc/portage/repo.postsync.d/sync_gentoo_herds_xml
+++ b/etc/portage/repo.postsync.d/sync_gentoo_herds_xml
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-source /etc/init.d/functions.sh
+source /lib/gentoo/functions.sh
 
 repository_name="${1}"
 repository_path="${3}"

--- a/etc/portage/repo.postsync.d/sync_gentoo_news
+++ b/etc/portage/repo.postsync.d/sync_gentoo_news
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-source /etc/init.d/functions.sh
+source /lib/gentoo/functions.sh
 
 repository_name="${1}"
 repository_path="${3}"


### PR DESCRIPTION
We currently source `/etc/init.d/functions.sh` in order to use `ebegin`/`ebegin`/`einfo`. This script is provided by `sys-apps/openrc`. This might cause problems on systems that do not have openrc installed. A better approach is to source `/lib/gentoo/functions.sh` from `sys-apps/gentoo-functions` which provides its own implementation of theses functions (independently of openrc) and was [created for exactly that reason](https://bugs.gentoo.org/show_bug.cgi?id=373219).
