### PR TITLE
Update readme and make sync files actually work :)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,17 +2,8 @@ This is not a full portage configuration. It contains only those parts that are
 necessary to set up a gentoo github mirror based sync system:
 
 * Configures Portage to sync via https://github.com/gentoo/gentoo.git URL.
-* Updates metadata-cache (the first update might take long, all subsequent ones not).
+* Updates metadata-cache.
 * Updates the dtd directory.
 * Updates the glsa directory.
 * Updates `herds.xml` file.
 * Updates the news directory.
-
-## Notes ##
-
-Note that typically most repositories other than `gentoo` don't come with a pregenerated cache. It is a good idea to generate/update their cache every time they are synced. One way to do this, is by activating the `example` hook script that portage installs by default in `/etc/portage/postsync.d`:
-
-```
-cp -i /etc/portage/repo.postsync.d/example /etc/portage/repo.postsync.d/gen_cache
-chmod +x /etc/portage/repo.postsync.d/gen_cache
-```

--- a/etc/portage/repo.postsync.d/sync_gentoo_cache
+++ b/etc/portage/repo.postsync.d/sync_gentoo_cache
@@ -1,11 +1,11 @@
 #!/bin/bash
 
+repository_name="${1}"
+repository_path="${3}"
+
 [[ ${repository_name} == "gentoo" ]] || exit 0
 
 source /lib/gentoo/functions.sh
-
-repository_name="${1}"
-repository_path="${3}"
 
 # Number of jobs for egencache, default is number or processors.
 parallel_jobs="$(nproc)"

--- a/etc/portage/repo.postsync.d/sync_gentoo_dtd
+++ b/etc/portage/repo.postsync.d/sync_gentoo_dtd
@@ -1,11 +1,11 @@
 #!/bin/bash
 
+repository_name="${1}"
+repository_path="${3}"
+
 [[ ${repository_name} == "gentoo" ]] || exit 0
 
 source /lib/gentoo/functions.sh
-
-repository_name="${1}"
-repository_path="${3}"
 
 DTDDIR="${repository_path}"/metadata/dtd
 ebegin "Updating DTDs"

--- a/etc/portage/repo.postsync.d/sync_gentoo_glsa
+++ b/etc/portage/repo.postsync.d/sync_gentoo_glsa
@@ -1,11 +1,11 @@
 #!/bin/bash
 
+repository_name="${1}"
+repository_path="${3}"
+
 [[ ${repository_name} == "gentoo" ]] || exit 0
 
 source /lib/gentoo/functions.sh
-
-repository_name="${1}"
-repository_path="${3}"
 
 GLSADIR="${repository_path}"/metadata/glsa
 ebegin "Updating GLSAs"

--- a/etc/portage/repo.postsync.d/sync_gentoo_herds_xml
+++ b/etc/portage/repo.postsync.d/sync_gentoo_herds_xml
@@ -1,11 +1,11 @@
 #!/bin/bash
 
+repository_name="${1}"
+repository_path="${3}"
+
 [[ ${repository_name} == "gentoo" ]] || exit 0
 
 source /lib/gentoo/functions.sh
-
-repository_name="${1}"
-repository_path="${3}"
 
 ebegin "Updating herds.xml"
 wget -q -O "${repository_path}"/metadata/herds.xml https://api.gentoo.org/packages/herds.xml

--- a/etc/portage/repo.postsync.d/sync_gentoo_news
+++ b/etc/portage/repo.postsync.d/sync_gentoo_news
@@ -1,11 +1,11 @@
 #!/bin/bash
 
+repository_name="${1}"
+repository_path="${3}"
+
 [[ ${repository_name} == "gentoo" ]] || exit 0
 
 source /lib/gentoo/functions.sh
-
-repository_name="${1}"
-repository_path="${3}"
 
 NEWSDIR="${repository_path}"/metadata/news
 ebegin "Updating news items"


### PR DESCRIPTION
- Metadata generation now always starts at last snapshot, so it should be reasonably fast
- I'm not sure how this ever worked, but... the repository_name was first compared with gentoo, and only afterwards set from the command line. Which meant the scripts never ran... Fixed and works now.
